### PR TITLE
feat: add support for Dart and Rust package version checking 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ An MCP server that provides tools for checking latest stable package versions fr
 - PyPI (Python)
 - Maven Central (Java)
 - Go Proxy (Go)
+- Crates.io (Rust)
+- pub.dev (Dart/Flutter)
 - Swift Packages (Swift)
 - AWS Bedrock (AI Models)
 - Docker Hub (Container Images)
@@ -19,6 +21,8 @@ This server helps LLMs ensure they're recommending up-to-date package versions w
 **IMPORTANT: As of version 2.0.0, mcp-package-version has been rewritten in Go, as such the configuration needs to be updated in your client - see the [Installation](#installation) section for more details.**
 
 <a href="https://glama.ai/mcp/servers/zkts2w92ba"><img width="380" height="200" src="https://glama.ai/mcp/servers/zkts2w92ba/badge" alt="https://github.com/sammcj/mcp-package-version MCP server" /></a>
+
+Now with support for Rust crates!
 
 ## Screenshot
 
@@ -279,6 +283,52 @@ Check the latest versions of Go packages from go.mod:
           "version": "v1.5.0"
         }
       ]
+    }
+  }
+}
+```
+
+### Rust Packages
+
+Check the latest versions of Rust crates from Cargo.toml:
+
+```json
+{
+  "name": "check_rust_versions",
+  "arguments": {
+    "dependencies": {
+      "serde": "1.0.136",
+      "tokio": "1.17.0",
+      "rocket": "0.5.0-rc.1",
+      "clap": { 
+        "version": "3.1.0",
+        "features": ["derive", "cargo"]
+      },
+      "log": {
+        "version": "0.4.17",
+        "optional": true
+      }
+    }
+  }
+}
+```
+
+### Dart Packages
+
+Check the latest versions of Dart packages from pubspec.yaml:
+
+```json
+{
+  "name": "check_dart_versions",
+  "arguments": {
+    "dependencies": {
+      "flutter": "sdk: flutter",
+      "http": "^0.13.4",
+      "provider": "^6.0.2",
+      "firebase_core": "^1.12.0",
+      "shared_preferences": {
+        "version": "^2.0.13"
+      }
     }
   }
 }

--- a/docs/dart.md
+++ b/docs/dart.md
@@ -1,0 +1,125 @@
+# Dart Packages Support
+
+This document explains how to use the Dart package version checking functionality in the MCP Package Version server.
+
+## Checking Dart Package Versions
+
+The MCP server provides a tool called `check_dart_versions` that allows you to check the latest versions of Dart packages from `pubspec.yaml`.
+
+### Example Usage
+
+```json
+{
+  "name": "check_dart_versions",
+  "arguments": {
+    "dependencies": {
+      "flutter": "sdk: flutter",
+      "http": "^0.13.4",
+      "provider": "^6.0.2",
+      "path": "^1.8.0",
+      "firebase_core": "^1.12.0",
+      "shared_preferences": {
+        "version": "^2.0.13"
+      },
+      "myproject": {
+        "path": "../myproject"
+      },
+      "flutter_auth": {
+        "git": {
+          "url": "https://github.com/example/flutter_auth.git",
+          "ref": "main"
+        }
+      }
+    }
+  }
+}
+```
+
+### Alternative Format
+
+You can also provide dependencies as an array:
+
+```json
+{
+  "name": "check_dart_versions",
+  "arguments": {
+    "dependencies": [
+      {
+        "name": "http",
+        "version": "^0.13.4"
+      },
+      {
+        "name": "provider",
+        "version": "^6.0.2"
+      },
+      {
+        "name": "flutter",
+        "version": "sdk: flutter",
+        "sdk": true
+      }
+    ]
+  }
+}
+```
+
+### Response Format
+
+The response will contain an array of packages with their current and latest versions:
+
+```json
+[
+  {
+    "name": "flutter",
+    "currentVersion": "sdk: flutter",
+    "latestVersion": "sdk dependency",
+    "registry": "pub.dev",
+    "skipped": true,
+    "skipReason": "SDK or environment dependency, version is managed by the SDK"
+  },
+  {
+    "name": "http",
+    "currentVersion": "^0.13.4",
+    "latestVersion": "1.1.0",
+    "registry": "pub.dev"
+  },
+  {
+    "name": "provider",
+    "currentVersion": "^6.0.2",
+    "latestVersion": "6.0.5",
+    "registry": "pub.dev"
+  },
+  {
+    "name": "myproject",
+    "currentVersion": "path: ../myproject",
+    "latestVersion": "special dependency",
+    "registry": "pub.dev",
+    "skipped": true,
+    "skipReason": "Git or path dependency, not a version constraint"
+  }
+]
+```
+
+## Implementation Details
+
+The Dart package version checker:
+
+1. Parses the dependencies provided in the request
+2. For each package, queries the pub.dev API to retrieve the latest version
+3. Returns a list of packages with their current and latest versions
+
+The implementation uses caching to avoid making repeated requests to the pub.dev API for the same packages within a short time period.
+
+### Special Cases
+
+The checker handles several special cases:
+
+- **SDK dependencies**: Flutter SDK packages (flutter, dart, etc.) are marked as "sdk dependency" and skipped
+- **Path dependencies**: Local path dependencies are skipped as they don't have a central registry version
+- **Git dependencies**: Dependencies fetched from git repositories are skipped
+
+## API Reference
+
+The Dart package version checker uses the pub.dev API to fetch the latest versions:
+
+- API Endpoint: `https://pub.dev/api/packages/{package_name}`
+- Response includes the package information and available versions

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -1,0 +1,99 @@
+# Rust Packages Support
+
+This document explains how to use the Rust crate version checking functionality in the MCP Package Version server.
+
+## Checking Rust Crate Versions
+
+The MCP server provides a tool called `check_rust_versions` that allows you to check the latest versions of Rust crates from `Cargo.toml`.
+
+### Example Usage
+
+```json
+{
+  "name": "check_rust_versions",
+  "arguments": {
+    "dependencies": {
+      "serde": "1.0.136",
+      "tokio": "1.17.0",
+      "rocket": "0.5.0-rc.1",
+      "clap": { 
+        "version": "3.1.0",
+        "features": ["derive", "cargo"]
+      },
+      "log": {
+        "version": "0.4.17",
+        "optional": true,
+        "default": false
+      }
+    }
+  }
+}
+```
+
+### Alternative Format
+
+You can also provide dependencies as an array:
+
+```json
+{
+  "name": "check_rust_versions",
+  "arguments": {
+    "dependencies": [
+      {
+        "name": "serde",
+        "version": "1.0.136"
+      },
+      {
+        "name": "tokio",
+        "version": "1.17.0"
+      }
+    ]
+  }
+}
+```
+
+### Response Format
+
+The response will contain an array of packages with their current and latest versions:
+
+```json
+[
+  {
+    "name": "serde",
+    "currentVersion": "1.0.136",
+    "latestVersion": "1.0.188",
+    "registry": "crates.io"
+  },
+  {
+    "name": "clap",
+    "currentVersion": "3.1.0",
+    "latestVersion": "4.4.10",
+    "registry": "crates.io",
+    "metadata": "{\"features\":[\"derive\",\"cargo\"]}"
+  },
+  {
+    "name": "log", 
+    "currentVersion": "0.4.17",
+    "latestVersion": "0.4.20",
+    "registry": "crates.io",
+    "metadata": "{\"optional\":true,\"default\":false}"
+  }
+]
+```
+
+## Implementation Details
+
+The Rust crate version checker:
+
+1. Parses the dependencies provided in the request
+2. For each crate, queries the crates.io API to retrieve the latest version
+3. Returns a list of crates with their current and latest versions
+
+The implementation uses caching to avoid making repeated requests to the crates.io API for the same crates within a short time period.
+
+## API Reference
+
+The Rust crate version checker uses the crates.io API to fetch the latest versions:
+
+- API Endpoint: `https://crates.io/api/v1/crates/{crate_name}`
+- Response includes the crate information and available versions

--- a/internal/handlers/dart.go
+++ b/internal/handlers/dart.go
@@ -1,0 +1,313 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// PubDevAPIURL is the base URL for the pub.dev API
+	PubDevAPIURL = "https://pub.dev/api/packages"
+)
+
+// DartHandler handles Dart package version checking
+type DartHandler struct {
+	client HTTPClient
+	cache  *sync.Map
+	logger *logrus.Logger
+}
+
+// NewDartHandler creates a new Dart handler
+func NewDartHandler(logger *logrus.Logger, cache *sync.Map) *DartHandler {
+	if cache == nil {
+		cache = &sync.Map{}
+	}
+	return &DartHandler{
+		client: DefaultHTTPClient,
+		cache:  cache,
+		logger: logger,
+	}
+}
+
+// DartPackageInfo represents information about a Dart package from the pub.dev API
+type DartPackageInfo struct {
+	Name     string               `json:"name"`
+	Latest   DartPackageVersion   `json:"latest"`
+	Versions []DartPackageVersion `json:"versions"`
+}
+
+// DartPackageVersion represents a version of a Dart package
+type DartPackageVersion struct {
+	Version     string `json:"version"`
+	PubspecYaml string `json:"pubspec,omitempty"`
+	Published   string `json:"published,omitempty"`
+	Retracted   bool   `json:"retracted,omitempty"`
+}
+
+// DartDependency represents a dependency in a Dart pubspec.yaml file
+type DartDependency struct {
+	Name        string `json:"name"`
+	Version     string `json:"version,omitempty"`
+	SDK         bool   `json:"sdk,omitempty"`
+	Environment bool   `json:"environment,omitempty"`
+}
+
+// getLatestVersion gets the latest version of a Dart package
+func (h *DartHandler) getLatestVersion(packageName string) (string, error) {
+	// Check cache first
+	if cachedVersion, ok := h.cache.Load(fmt.Sprintf("dart:%s", packageName)); ok {
+		h.logger.WithField("package", packageName).Debug("Using cached Dart package version")
+		return cachedVersion.(string), nil
+	}
+
+	// Skip SDK or environment dependencies
+	if packageName == "flutter" || packageName == "dart" || packageName == "flutter_test" || packageName == "flutter_driver" {
+		return "sdk", nil
+	}
+
+	// Construct URL
+	packageURL := fmt.Sprintf("%s/%s", PubDevAPIURL, packageName)
+	h.logger.WithFields(logrus.Fields{
+		"package": packageName,
+		"url":     packageURL,
+	}).Debug("Fetching Dart package info")
+
+	// Make request
+	body, err := MakeRequestWithLogger(h.client, h.logger, "GET", packageURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch Dart package info: %w", err)
+	}
+
+	// Parse response
+	var info DartPackageInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return "", fmt.Errorf("failed to parse Dart package info: %w", err)
+	}
+
+	// Get latest non-retracted version
+	var latestVersion string
+	if !info.Latest.Retracted {
+		latestVersion = info.Latest.Version
+	} else {
+		// If latest is retracted, find the latest non-retracted version
+		var validVersions []string
+		for _, version := range info.Versions {
+			if !version.Retracted {
+				validVersions = append(validVersions, version.Version)
+			}
+		}
+
+		if len(validVersions) == 0 {
+			return "", fmt.Errorf("no valid versions found for package %s", packageName)
+		}
+
+		// Sort versions and get the latest
+		sort.Slice(validVersions, func(i, j int) bool {
+			cmp, err := CompareVersions(validVersions[i], validVersions[j])
+			if err != nil {
+				h.logger.WithError(err).WithFields(logrus.Fields{
+					"version1": validVersions[i],
+					"version2": validVersions[j],
+				}).Error("Failed to compare versions")
+				return false
+			}
+			return cmp > 0
+		})
+
+		latestVersion = validVersions[0]
+	}
+
+	// Cache result
+	h.cache.Store(fmt.Sprintf("dart:%s", packageName), latestVersion)
+
+	return latestVersion, nil
+}
+
+// GetLatestVersion gets the latest versions of Dart packages
+func (h *DartHandler) GetLatestVersion(ctx context.Context, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	h.logger.Debug("Getting latest Dart package versions")
+
+	// Parse dependencies
+	depsRaw, ok := args["dependencies"]
+	if !ok {
+		return nil, fmt.Errorf("missing required parameter: dependencies")
+	}
+
+	// Handle different input formats
+	var dependencies []DartDependency
+
+	// Log the raw dependencies for debugging
+	h.logger.WithField("dependencies", fmt.Sprintf("%+v", depsRaw)).Debug("Raw dependencies")
+
+	// Handle dependencies as a map (like in pubspec.yaml)
+	if depsMap, ok := depsRaw.(map[string]interface{}); ok {
+		for name, versionRaw := range depsMap {
+			h.logger.WithFields(logrus.Fields{
+				"name":    name,
+				"version": versionRaw,
+			}).Debug("Processing dependency")
+
+			// Identify if it's an SDK dependency
+			isSDK := false
+			isEnv := false
+
+			// Check if the package name indicates it's from an SDK
+			if name == "flutter" || name == "dart" || strings.HasPrefix(name, "flutter:") || strings.HasPrefix(name, "dart:") {
+				isSDK = true
+			}
+
+			// Check if it's an environment dependency (typically starts with "sdk:")
+			if strings.HasPrefix(name, "sdk:") {
+				isEnv = true
+			}
+
+			// Handle version as a string
+			if versionStr, ok := versionRaw.(string); ok {
+				dependencies = append(dependencies, DartDependency{
+					Name:        name,
+					Version:     versionStr,
+					SDK:         isSDK,
+					Environment: isEnv,
+				})
+			} else if versionMap, ok := versionRaw.(map[string]interface{}); ok {
+				// Handle version as an object
+				var version string
+				if v, ok := versionMap["version"].(string); ok {
+					version = v
+				} else if v, ok := versionMap["path"].(string); ok {
+					// Path dependency
+					version = fmt.Sprintf("path: %s", v)
+				} else if v, ok := versionMap["git"].(map[string]interface{}); ok {
+					// Git dependency
+					url, _ := v["url"].(string)
+					ref, _ := v["ref"].(string)
+					if ref != "" {
+						version = fmt.Sprintf("git: %s@%s", url, ref)
+					} else {
+						version = fmt.Sprintf("git: %s", url)
+					}
+				}
+
+				dependencies = append(dependencies, DartDependency{
+					Name:        name,
+					Version:     version,
+					SDK:         isSDK,
+					Environment: isEnv,
+				})
+			}
+		}
+	} else if depsArray, ok := depsRaw.([]interface{}); ok {
+		// Handle dependencies as an array of objects
+		for _, depRaw := range depsArray {
+			if depMap, ok := depRaw.(map[string]interface{}); ok {
+				var dep DartDependency
+
+				if name, ok := depMap["name"].(string); ok {
+					dep.Name = name
+				} else {
+					continue
+				}
+
+				if version, ok := depMap["version"].(string); ok {
+					dep.Version = version
+				}
+
+				// Check if it's an SDK dependency
+				if sdk, ok := depMap["sdk"].(bool); ok {
+					dep.SDK = sdk
+				} else if strings.HasPrefix(dep.Name, "flutter:") || strings.HasPrefix(dep.Name, "dart:") ||
+					dep.Name == "flutter" || dep.Name == "dart" {
+					dep.SDK = true
+				}
+
+				// Check if it's an environment dependency
+				if env, ok := depMap["environment"].(bool); ok {
+					dep.Environment = env
+				} else if strings.HasPrefix(dep.Name, "sdk:") {
+					dep.Environment = true
+				}
+
+				dependencies = append(dependencies, dep)
+			}
+		}
+	} else {
+		return nil, fmt.Errorf("invalid dependencies format: expected object or array, got %T", depsRaw)
+	}
+
+	// Process each dependency
+	results := make([]PackageVersion, 0, len(dependencies))
+	for _, dep := range dependencies {
+		h.logger.WithFields(logrus.Fields{
+			"package": dep.Name,
+			"version": dep.Version,
+			"sdk":     dep.SDK,
+			"env":     dep.Environment,
+		}).Debug("Processing Dart package")
+
+		// Skip SDK or environment dependencies
+		if dep.SDK || dep.Environment {
+			results = append(results, PackageVersion{
+				Name:           dep.Name,
+				CurrentVersion: StringPtr(dep.Version),
+				LatestVersion:  "sdk dependency",
+				Registry:       "pub.dev",
+				Skipped:        true,
+				SkipReason:     "SDK or environment dependency, version is managed by the SDK",
+			})
+			continue
+		}
+
+		// Skip dependencies with special formats (git, path)
+		if strings.HasPrefix(dep.Version, "git:") || strings.HasPrefix(dep.Version, "path:") {
+			results = append(results, PackageVersion{
+				Name:           dep.Name,
+				CurrentVersion: StringPtr(dep.Version),
+				LatestVersion:  "special dependency",
+				Registry:       "pub.dev",
+				Skipped:        true,
+				SkipReason:     "Git or path dependency, not a version constraint",
+			})
+			continue
+		}
+
+		// Get latest version
+		latestVersion, err := h.getLatestVersion(dep.Name)
+		if err != nil {
+			h.logger.WithFields(logrus.Fields{
+				"package": dep.Name,
+				"error":   err.Error(),
+			}).Error("Failed to get Dart package info")
+			results = append(results, PackageVersion{
+				Name:           dep.Name,
+				CurrentVersion: StringPtr(dep.Version),
+				LatestVersion:  "unknown",
+				Registry:       "pub.dev",
+				Skipped:        true,
+				SkipReason:     fmt.Sprintf("Failed to fetch package info: %v", err),
+			})
+			continue
+		}
+
+		// Add result
+		results = append(results, PackageVersion{
+			Name:           dep.Name,
+			CurrentVersion: StringPtr(dep.Version),
+			LatestVersion:  latestVersion,
+			Registry:       "pub.dev",
+		})
+	}
+
+	// Sort results by name
+	sort.Slice(results, func(i, j int) bool {
+		return strings.ToLower(results[i].Name) < strings.ToLower(results[j].Name)
+	})
+
+	return NewToolResultJSON(results)
+}

--- a/internal/handlers/rust.go
+++ b/internal/handlers/rust.go
@@ -1,0 +1,239 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// CratesioAPIURL is the base URL for the crates.io API
+	CratesioAPIURL = "https://crates.io/api/v1"
+)
+
+// RustHandler handles Rust package version checking
+type RustHandler struct {
+	client HTTPClient
+	cache  *sync.Map
+	logger *logrus.Logger
+}
+
+// NewRustHandler creates a new Rust handler
+func NewRustHandler(logger *logrus.Logger, cache *sync.Map) *RustHandler {
+	if cache == nil {
+		cache = &sync.Map{}
+	}
+	return &RustHandler{
+		client: DefaultHTTPClient,
+		cache:  cache,
+		logger: logger,
+	}
+}
+
+// RustCrateInfo represents information about a Rust crate from the crates.io API
+type RustCrateInfo struct {
+	Crate struct {
+		ID               string `json:"id"`
+		Name             string `json:"name"`
+		Description      string `json:"description"`
+		MaxVersion       string `json:"max_version"`
+		MaxStableVersion string `json:"max_stable_version"`
+	} `json:"crate"`
+	Versions []struct {
+		ID      string `json:"id"`
+		Version string `json:"num"`
+		Yanked  bool   `json:"yanked"`
+	} `json:"versions"`
+}
+
+// RustDependency represents a dependency in a Rust Cargo.toml file
+type RustDependency struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+	// Additional fields like features, optional, etc. could be added here
+}
+
+// getLatestVersion gets the latest version of a Rust crate
+func (h *RustHandler) getLatestVersion(crateName string) (string, error) {
+	// Check cache first
+	if cachedVersion, ok := h.cache.Load(fmt.Sprintf("rust:%s", crateName)); ok {
+		h.logger.WithField("crate", crateName).Debug("Using cached Rust crate version")
+		return cachedVersion.(string), nil
+	}
+
+	// Construct URL
+	crateURL := fmt.Sprintf("%s/crates/%s", CratesioAPIURL, crateName)
+	h.logger.WithFields(logrus.Fields{
+		"crate": crateName,
+		"url":   crateURL,
+	}).Debug("Fetching Rust crate info")
+
+	// Make request
+	body, err := MakeRequestWithLogger(h.client, h.logger, "GET", crateURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch Rust crate info: %w", err)
+	}
+
+	// Parse response
+	var info RustCrateInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return "", fmt.Errorf("failed to parse Rust crate info: %w", err)
+	}
+
+	// Get latest stable version
+	var latestVersion string
+	if info.Crate.MaxStableVersion != "" {
+		// Use the max stable version if available
+		latestVersion = info.Crate.MaxStableVersion
+	} else if info.Crate.MaxVersion != "" {
+		// Fallback to max version if max stable is not available
+		latestVersion = info.Crate.MaxVersion
+	} else {
+		// If neither is available, try to find the latest non-yanked version
+		var latestVersions []string
+		for _, version := range info.Versions {
+			if !version.Yanked {
+				latestVersions = append(latestVersions, version.Version)
+			}
+		}
+
+		if len(latestVersions) == 0 {
+			return "", fmt.Errorf("no valid versions found for crate %s", crateName)
+		}
+
+		// Sort versions and get the latest
+		sort.Slice(latestVersions, func(i, j int) bool {
+			cmp, err := CompareVersions(latestVersions[i], latestVersions[j])
+			if err != nil {
+				h.logger.WithError(err).WithFields(logrus.Fields{
+					"version1": latestVersions[i],
+					"version2": latestVersions[j],
+				}).Error("Failed to compare versions")
+				return false
+			}
+			return cmp > 0
+		})
+
+		latestVersion = latestVersions[0]
+	}
+
+	// Cache result
+	h.cache.Store(fmt.Sprintf("rust:%s", crateName), latestVersion)
+
+	return latestVersion, nil
+}
+
+// GetLatestVersion gets the latest versions of Rust packages
+func (h *RustHandler) GetLatestVersion(ctx context.Context, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	h.logger.Debug("Getting latest Rust package versions")
+
+	// Parse dependencies
+	depsRaw, ok := args["dependencies"]
+	if !ok {
+		return nil, fmt.Errorf("missing required parameter: dependencies")
+	}
+
+	// Handle different input formats
+	var dependencies []RustDependency
+
+	// Log the raw dependencies for debugging
+	h.logger.WithField("dependencies", fmt.Sprintf("%+v", depsRaw)).Debug("Raw dependencies")
+
+	// Handle dependencies as a map (like in Cargo.toml)
+	if depsMap, ok := depsRaw.(map[string]interface{}); ok {
+		for name, versionRaw := range depsMap {
+			h.logger.WithFields(logrus.Fields{
+				"name":    name,
+				"version": versionRaw,
+			}).Debug("Processing dependency")
+
+			// Handle version as a string
+			if versionStr, ok := versionRaw.(string); ok {
+				dependencies = append(dependencies, RustDependency{
+					Name:    name,
+					Version: versionStr,
+				})
+			} else if versionMap, ok := versionRaw.(map[string]interface{}); ok {
+				// Handle version as an object (e.g., with features, etc.)
+				var version string
+				if v, ok := versionMap["version"].(string); ok {
+					version = v
+				}
+
+				dependencies = append(dependencies, RustDependency{
+					Name:    name,
+					Version: version,
+				})
+			}
+		}
+	} else if depsArray, ok := depsRaw.([]interface{}); ok {
+		// Handle dependencies as an array of objects
+		for _, depRaw := range depsArray {
+			if depMap, ok := depRaw.(map[string]interface{}); ok {
+				var dep RustDependency
+
+				if name, ok := depMap["name"].(string); ok {
+					dep.Name = name
+				} else {
+					continue
+				}
+
+				if version, ok := depMap["version"].(string); ok {
+					dep.Version = version
+				}
+
+				dependencies = append(dependencies, dep)
+			}
+		}
+	} else {
+		return nil, fmt.Errorf("invalid dependencies format: expected object or array, got %T", depsRaw)
+	}
+
+	// Process each dependency
+	results := make([]PackageVersion, 0, len(dependencies))
+	for _, dep := range dependencies {
+		h.logger.WithFields(logrus.Fields{
+			"crate":   dep.Name,
+			"version": dep.Version,
+		}).Debug("Processing Rust crate")
+
+		// Get latest version
+		latestVersion, err := h.getLatestVersion(dep.Name)
+		if err != nil {
+			h.logger.WithFields(logrus.Fields{
+				"crate": dep.Name,
+				"error": err.Error(),
+			}).Error("Failed to get Rust crate info")
+			results = append(results, PackageVersion{
+				Name:           dep.Name,
+				CurrentVersion: StringPtr(dep.Version),
+				LatestVersion:  "unknown",
+				Registry:       "crates.io",
+				Skipped:        true,
+				SkipReason:     fmt.Sprintf("Failed to fetch crate info: %v", err),
+			})
+			continue
+		}
+
+		// Add result
+		results = append(results, PackageVersion{
+			Name:           dep.Name,
+			CurrentVersion: StringPtr(dep.Version),
+			LatestVersion:  latestVersion,
+			Registry:       "crates.io",
+		})
+	}
+
+	// Sort results by name
+	sort.Slice(results, func(i, j int) bool {
+		return strings.ToLower(results[i].Name) < strings.ToLower(results[j].Name)
+	})
+
+	return NewToolResultJSON(results)
+}

--- a/internal/handlers/types.go
+++ b/internal/handlers/types.go
@@ -8,12 +8,13 @@ type PackageVersion struct {
 	Registry       string  `json:"registry"`
 	Skipped        bool    `json:"skipped,omitempty"`
 	SkipReason     string  `json:"skipReason,omitempty"`
+	Metadata       *string `json:"metadata,omitempty"` // JSON string with additional package-specific metadata
 }
 
 // VersionConstraint represents constraints for package version updates
 type VersionConstraint struct {
-	MajorVersion   *int  `json:"majorVersion,omitempty"`
-	ExcludePackage bool  `json:"excludePackage,omitempty"`
+	MajorVersion   *int `json:"majorVersion,omitempty"`
+	ExcludePackage bool `json:"excludePackage,omitempty"`
 }
 
 // VersionConstraints maps package names to their constraints

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -129,13 +129,13 @@ func (s *PackageVersionServer) Initialize(srv *mcpserver.MCPServer) error {
 		"pid": pid,
 	}).Debug("Starting package-version MCP server")
 
-	s.logger.Debug("Initialising package version handlers")
-
-	// Register tools and handlers
+	s.logger.Debug("Initialising package version handlers") // Register tools and handlers
 	s.registerNpmTool(srv)
 	s.registerPythonTools(srv)
 	s.registerJavaTools(srv)
 	s.registerGoTool(srv)
+	s.registerRustTool(srv)
+	s.registerDartTool(srv)
 	s.registerBedrockTools(srv)
 	s.registerDockerTool(srv)
 	s.registerSwiftTool(srv)

--- a/pkg/server/server_dart.go
+++ b/pkg/server/server_dart.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/sammcj/mcp-package-version/v2/internal/handlers"
+)
+
+// registerDartTool registers the Dart version checking tool
+func (s *PackageVersionServer) registerDartTool(srv *mcpserver.MCPServer) {
+	// Create Dart handler with a logger
+	dartHandler := handlers.NewDartHandler(s.logger, s.sharedCache)
+
+	dartTool := mcp.NewTool("check_dart_versions",
+		mcp.WithDescription("Get the current, up to date package versions to use when adding Dart packages or updating pubspec.yaml"),
+		mcp.WithObject("dependencies",
+			mcp.Required(),
+			mcp.Description("Required: Dependencies from pubspec.yaml"),
+		),
+	)
+
+	// Add Dart handler
+	srv.AddTool(dartTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		s.logger.WithField("tool", "check_dart_versions").Debug("Received request")
+		return dartHandler.GetLatestVersion(ctx, request.Params.Arguments)
+	})
+}

--- a/pkg/server/server_rust.go
+++ b/pkg/server/server_rust.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/sammcj/mcp-package-version/v2/internal/handlers"
+)
+
+// registerRustTool registers the Rust version checking tool
+func (s *PackageVersionServer) registerRustTool(srv *mcpserver.MCPServer) {
+	// Create Rust handler with a logger
+	rustHandler := handlers.NewRustHandler(s.logger, s.sharedCache)
+
+	rustTool := mcp.NewTool("check_rust_versions",
+		mcp.WithDescription("Get the current, up to date package versions to use when adding Rust crates or updating Cargo.toml"),
+		mcp.WithObject("dependencies",
+			mcp.Required(),
+			mcp.Description("Required: Dependencies from Cargo.toml"),
+		),
+	)
+
+	// Add Rust handler
+	srv.AddTool(rustTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		s.logger.WithField("tool", "check_rust_versions").Debug("Received request")
+		return rustHandler.GetLatestVersion(ctx, request.Params.Arguments)
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Rust (crates.io) and Dart/Flutter (pub.dev) package version checks, enabling retrieval of latest versions for Cargo.toml and pubspec.yaml dependencies.

- Documentation
  - Updated README to include Rust/Dart support, registry additions, and usage examples.
  - Added dedicated docs for Rust and Dart tools with input formats, examples, response fields, and handling of skipped dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->